### PR TITLE
Sync with latest changes

### DIFF
--- a/.github/workflows/update-discord-event.yml
+++ b/.github/workflows/update-discord-event.yml
@@ -3,6 +3,10 @@ name: Update Discord Event
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-event:
     runs-on: ubuntu-latest

--- a/scripts/update-discord-event.sh
+++ b/scripts/update-discord-event.sh
@@ -6,15 +6,7 @@ TOKEN="${DISCORD_BOT_TOKEN:?}"
 INDEX_PATH="index.html"
 
 # Fetch events from Discord
-# EVENTS_JSON=$(curl -s -H "Authorization: Bot $TOKEN" "https://discord.com/api/guilds/$GUILD_ID/scheduled-events")
-
-# Uncomment the following to test without fetching from Discord
-
-# Example: No upcoming events
-# EVENTS_JSON="[]"
-
-# Example: One upcoming event
-EVENTS_JSON='[{"id": "1388947874875834548","guild_id": "1388934107974729769","name": "Test Meetup #1","description": "This is a test event #1","channel_id": null,"creator_id": "201049866967711744","creator": {"id": "201049866967711744","username": "atechadventurer","avatar": "6beb07178e4af1b4a1cce0ff7de32325","discriminator": "0","public_flags": 4194432,"flags": 4194432,"banner": "a_eade0a9638ac7b3884ce35ae620d7715","accent_color": 4804990,"global_name": "ATechAdventurer","avatar_decoration_data": null,"collectibles": null,"banner_color": "#49517e","clan": null,"primary_guild": null},"image": null,"scheduled_start_time": "2025-06-30T19:00:00+00:00","scheduled_end_time": "2025-06-30T20:00:00+00:00","status": 1,"entity_type": 3,"entity_id": null,"recurrence_rule": null,"privacy_level": 2,"sku_ids": [],"guild_scheduled_event_exceptions": [],"entity_metadata": {"location": "Black Sheep Lodge - 2108 S Lamar Blvd, Austin, TX 78704"}}]'
+EVENTS_JSON=$(curl -s -H "Authorization: Bot $TOKEN" "https://discord.com/api/guilds/$GUILD_ID/scheduled-events")
 
 # Find the next upcoming event (status == 1, soonest start time)
 NEXT_EVENT=$(echo "$EVENTS_JSON" | jq '[.[] | select(.status==1)] | sort_by(.scheduled_start_time) | .[0]')


### PR DESCRIPTION
This pull request updates the Discord event workflow and its associated script to support multiple HTML files and improve compatibility across operating systems. The changes include adding permissions to the workflow, enhancing the script to handle multiple HTML files dynamically, and ensuring compatibility with both GNU and BSD date commands.

### Workflow updates:
* [`.github/workflows/update-discord-event.yml`](diffhunk://#diff-89db017591243d0370331b7be42a00d5a6bf57bceba8b29316cf79674b3a0f7dR6-R9): Added `contents: write` and `pull-requests: write` permissions to the workflow to enable necessary actions.

### Script enhancements for HTML file updates:
* [`scripts/update-discord-event.sh`](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L6-R45): Replaced the single `index.html` file with a dynamic list of HTML files (`HTML_FILES`) to update event-related content across multiple pages.
* [`scripts/update-discord-event.sh`](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L43-R64): Updated logic to iterate over all HTML files when no upcoming events are found, modifying both the header button and dialog content dynamically.
* [`scripts/update-discord-event.sh`](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L54-R94): Enhanced the script to update all HTML files dynamically when an upcoming event is detected, including formatting the event date for display in Central Time. [[1]](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L54-R94) [[2]](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L82-R118)

### Compatibility improvements:
* [`scripts/update-discord-event.sh`](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L6-R45): Added OS detection logic to ensure compatibility for `sed` and `date` commands across Linux and macOS. [[1]](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L6-R45) [[2]](diffhunk://#diff-c729f146c94f2ab78072ff64eb76a82397c69e05bd2f95509127aa21bb298ef1L54-R94)